### PR TITLE
[codex] configure dev server scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,11 @@
 
 ## Commands
 
-- `npm run dev` - start the Vite development server.
+- `npm run dev` - start the Vite development server and open the app in the
+  default system browser at `/Weather/`.
+- `npm start` - start the Vite development server and open the app in the
+  default system browser at `/Weather/`.
+- `npm run stop` - stop the Vite development server running on port `5173`.
 - `npm run build` - create the production build.
 - `npm run format` - format supported files with Prettier.
 - `npm run format:check` - verify formatting without changing files.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "deploy": "gh-pages -d dist",
     "dev": "vite",
     "start": "vite",
+    "stop": "node scripts/stop-dev-server.mjs",
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/scripts/stop-dev-server.mjs
+++ b/scripts/stop-dev-server.mjs
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+
+const port = process.env.VITE_DEV_SERVER_PORT ?? "5173";
+
+let output = "";
+
+try {
+  output = execFileSync("lsof", [`-tiTCP:${port}`, "-sTCP:LISTEN"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+} catch {
+  console.log(`No development server found on port ${port}.`);
+  process.exit(0);
+}
+
+const processIds = output
+  .split("\n")
+  .map((processId) => processId.trim())
+  .filter(Boolean);
+
+if (processIds.length === 0) {
+  console.log(`No development server found on port ${port}.`);
+  process.exit(0);
+}
+
+for (const processId of processIds) {
+  process.kill(Number(processId), "SIGTERM");
+}
+
+console.log(`Stopped development server on port ${port}.`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   base: "/Weather/",
   plugins: [react()],
+  server: {
+    open: "/Weather/",
+  },
   test: {
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",


### PR DESCRIPTION
## Summary

- Configure Vite to open the app at `/Weather/` in the default system browser when the dev server starts.
- Add `npm run stop` with a Node helper that terminates the Vite listener on port `5173`.
- Document the dev, start, and stop commands in `AGENTS.md`.

## Impact

Developers can start the project and land directly in the browser, then stop the local Vite server with a project script when needed.

## Validation

- `npm run validate`